### PR TITLE
Add plain-org-wiki-refile-targets

### DIFF
--- a/plain-org-wiki.el
+++ b/plain-org-wiki.el
@@ -44,21 +44,34 @@
 (defvar plain-org-wiki-extra-dirs nil
   "List of extra directories in addition to `plain-org-wiki-directory'.")
 
-(defun plain-org-wiki-files-in-dir (dir)
-  "Return a list of cons cells for DIR.
-Each cons cell is a name and file path."
+(defun plain-org-wiki-files-in-dir* (dir)
+  "Return a list of absolute paths of org files in DIR."
   (let ((default-directory dir))
     (mapcar
-     (lambda (x)
-       (cons (file-name-sans-extension x)
-             (expand-file-name x)))
+     #'expand-file-name
      (append
       (file-expand-wildcards "*.org")
       (file-expand-wildcards "*.org.gpg")))))
 
+(defun plain-org-wiki-files-in-dir (dir)
+  "Return a list of cons cells for DIR.
+Each cons cell is a name and file path."
+  (mapcar
+   (lambda (x)
+     (cons (file-name-sans-extension x)
+           x))
+   (plain-org-wiki-files-in-dir* dir)))
+
 (defun plain-org-wiki-files ()
-  "Return .org files in `plain-org-wiki-directory'."
+  "Return cons cells for files in `plain-org-wiki-directory'.
+Each cons cell is a name and file path."
   (cl-mapcan #'plain-org-wiki-files-in-dir
+             (cons plain-org-wiki-directory plain-org-wiki-extra-dirs)))
+
+(defun plain-org-wiki-refile-targets ()
+  "Return a list of files in `plain-org-wiki-directory' suitable
+for use in `org-refile-targets'."
+  (cl-mapcan #'plain-org-wiki-files-in-dir*
              (cons plain-org-wiki-directory plain-org-wiki-extra-dirs)))
 
 (defvar ffip-project-root)


### PR DESCRIPTION
Also did some refactoring of existing functions to reuse logic. Added
plain-org-wiki-files-in-dir* in order to re-use the file-expand-wildcards
matchers.